### PR TITLE
Minimize dependencies and bump to 0.1.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.16.5
 yarn_mappings=1.16.5+build.1
 loader_version=0.10.8
 # Mod Properties
-mod_version=0.1.2-SNAPSHOT
+mod_version=0.1.2
 maven_group=me.steinborn
 archives_base_name=lazydfu
 # Dependencies

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
     "lazydfu.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.10.0",
-    "minecraft": ">=1.16.4"
+    "fabricloader": ">=0.7.0",
+    "minecraft": ">=1.14"
   }
 }


### PR DESCRIPTION
Mod runs fine from 1.14 all the way through the latest snapshot, so I just removed that version dependency altogether. Lowered the loader one as well while I was at it, though it's not particularly important