### PR TITLE
Minor Changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.5-SNAPSHOT'
+    id 'fabric-loom' version '0.6-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/src/main/java/me/steinborn/lazydfu/mixin/SchemasMixin.java
+++ b/src/main/java/me/steinborn/lazydfu/mixin/SchemasMixin.java
@@ -17,26 +17,29 @@ import java.util.concurrent.TimeUnit;
 
 @Mixin(Schemas.class)
 public class SchemasMixin {
-//    private static long startTime;
-//
-//    @Inject(method = "create", at = @At("HEAD"))
-//    private static void create$recordStart(CallbackInfoReturnable<DataFixer> ci) {
-//        startTime = System.nanoTime();
-//    }
-
+/**
+ *    private static long startTime;
+ *
+ *    @Inject(method = "create", at = @At("HEAD"))
+ *    private static void create$recordStart(CallbackInfoReturnable<DataFixer> ci) {
+ *        startTime = System.nanoTime();
+ *    }
+ */
     @Redirect(method = "create", at = @At(value = "NEW", target = "com/mojang/datafixers/DataFixerBuilder"))
     private static DataFixerBuilder create$replaceBuilder(int dataVersion) {
         return new LazyDataFixerBuilder(dataVersion);
     }
 
-//    @Inject(method = "create", at = @At("RETURN"))
-//    private static void create$doEnd(CallbackInfoReturnable<DataFixer> ci) {
-//        new Thread(() -> {
-//            if (((ForkJoinPool)Util.getBootstrapExecutor()).awaitQuiescence(Integer.MAX_VALUE, TimeUnit.MILLISECONDS)) {
-//                System.out.println("Initialization complete in " + ((System.nanoTime() - startTime) / 1_000_000) + "ms");
-//            } else {
-//                System.out.println("Initialization still didn't complete in " + ((System.nanoTime() - startTime) / 1_000_000) + "ms");
-//            }
-//        }).start();
-//    }
+/**
+ *    @Inject(method = "create", at = @At("RETURN"))
+ *    private static void create$doEnd(CallbackInfoReturnable<DataFixer> ci) {
+ *        new Thread(() -> {
+ *            if (((ForkJoinPool)Util.getBootstrapExecutor()).awaitQuiescence(Integer.MAX_VALUE, TimeUnit.MILLISECONDS)) {
+ *                System.out.println("Initialization complete in " + ((System.nanoTime() - startTime) / 1_000_000) + "ms");
+ *            } else {
+ *                System.out.println("Initialization still didn't complete in " + ((System.nanoTime() - startTime) / 1_000_000) + "ms");
+ *            }
+ *        }).start();
+ *    }
+ */
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,7 +7,11 @@
   "authors": [
     "tuxed"
   ],
-  "contact": {},
+  "contact": {
+  "homepage": "https://github.com/astei/lazydfu",
+  "sources": "https://github.com/astei/lazydfu",
+  "issues": "https://github.com/astei/lazydfu/issues"
+  },
   "license": "MIT",
   "icon": "assets/lazydfu/icon.png",
   "environment": "*",

--- a/src/main/resources/lazydfu.mixins.json
+++ b/src/main/resources/lazydfu.mixins.json
@@ -6,8 +6,6 @@
   "mixins": [
     "SchemasMixin"
   ],
-  "client": [
-  ],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
- Bump loom version so that ppl using JDK 16 can use (they also need Gradle 7, but they can install that on their end and run `./gradle build` to use the gradle on their computer rather than the gradle wrapper, but the loom version bump is a change that needs to be done in the mod itself)
- Add links to `fabric.mod.json`
- Remove useless 'client' part of `lazydfu.mixins.json`
- Change comments to multiline comments