### PR TITLE
replace overwrite with inject

### DIFF
--- a/src/main/java/me/steinborn/lazydfu/mixin/SharedConstantsMixin.java
+++ b/src/main/java/me/steinborn/lazydfu/mixin/SharedConstantsMixin.java
@@ -2,16 +2,18 @@ package me.steinborn.lazydfu.mixin;
 
 import net.minecraft.SharedConstants;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(SharedConstants.class)
+@Mixin(value = SharedConstants.class, priority = Integer.MAX_VALUE)
 public class SharedConstantsMixin {
     /**
      * @author Andrew Steinborn
      * @reason Disables any possibility of enabling DFU "optimizations"
      */
-    @Overwrite
-    public static void enableDataFixerOptimizations() {
-        // Turn this method into a no-op.
+    @Inject(method = "enableDataFixerOptimizations", at = @At("HEAD"), cancellable = true)
+    private static void disableDataFixerOptimizations(CallbackInfo ci) {
+        ci.cancel();
     }
 }


### PR DESCRIPTION
functionally is the same thing, but in the case that another mod also targets `enableDataFixerOptimizations`, mixin won't die. I made the priority `Integer.MAX_VALUE` to ensure that this mixin is applied last (and therefore the `ci.cancel()` is always at the top).